### PR TITLE
Added the slack webhook url for failure notification

### DIFF
--- a/.github/workflows/workflow-dispatch-status-check.yaml
+++ b/.github/workflows/workflow-dispatch-status-check.yaml
@@ -42,6 +42,9 @@ on:
       app_secret:
         description: Passing App secret for the GHA Token creation
         required: true
+      slack_failure_webhook_url:
+        description: Slack Webhook URL to send failure notifications
+        required: true
     outputs:
         workflow_status:
           description: Get the status of the workflow
@@ -96,4 +99,4 @@ jobs:
 #          message_format: "{emoji} *{workflow}* ${{ steps.workflow_dispatch.outputs.workflow-conclusion }} triggered from ${{fromJson(inputs.inputs).source}}"
           mention_groups_when: 'failure'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_failure_webhook_url }}


### PR DESCRIPTION
> Adding **slack_failure_webhook_url**  to the workflow

## Summary
 Adding **slack_failure_webhook_url**  to the workflow

## Links
https://sph.atlassian.net/browse/CAAS-279

## Major Changes
NA
