### PR TITLE
Support sentry

### DIFF
--- a/.github/workflows/workflow-dispatch-node-lambda-zip.yaml
+++ b/.github/workflows/workflow-dispatch-node-lambda-zip.yaml
@@ -31,6 +31,10 @@ on:
         required: false
         default: ""
         type: string
+    secrets:
+      SENTRY_AUTH_TOKEN:
+        description: "Sentry auth token"
+        required: true
 
 jobs:
   deploy_zip:
@@ -63,16 +67,19 @@ jobs:
         env:
           HUSKY: 0
         run: |
-          npm ci --ignore-scripts ${{ inputs.additionalInstallOptions }}
+          npm ci ${{ inputs.additionalInstallOptions }}
 
       - name: 🛠️ Build lambda
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          GITHUB_SHA: ${{ github.sha }}
         run: npm run build
 
       - name: 📥 Install dependencies (production)
         env:
           HUSKY: 0
         run: |
-          npm ci --omit=dev --ignore-scripts
+          npm ci --omit=dev
 
       - name: 🔩 Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/workflow-dispatch-node-lambda-zip.yaml
+++ b/.github/workflows/workflow-dispatch-node-lambda-zip.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: 🛠️ Build lambda
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_SHA: ${{ inputs.commitGithubSHA || github.sha }}
         run: npm run build
 
       - name: 📥 Install dependencies (production)

--- a/.github/workflows/workflow-dispatch-node-lambda-zip.yaml
+++ b/.github/workflows/workflow-dispatch-node-lambda-zip.yaml
@@ -31,6 +31,11 @@ on:
         required: false
         default: ""
         type: string
+      commitGithubSHA:
+        description: "Github SHA of target commit on the target repo and branch"
+        required: false
+        default: ""
+        type: string
     secrets:
       SENTRY_AUTH_TOKEN:
         description: "Sentry auth token"


### PR DESCRIPTION
## Summary

Add `SENTRY_AUTH_TOKEN` and `GITHUB_SHA` as secrets and inputs to support Sentry sourcemaps upload.
